### PR TITLE
Reduce resource requirements for deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To install Tigris Server you need to install the following components in a seque
 - kubernetes cluster with sufficient resources
 - this repository :- )
 
-Tested with k3s running on a 16 vCPU / 32G RAM node.
+Tested with k3s running on a 2 vCPU / 8G RAM node.
 
 # Deploy FDB Operator
 
@@ -61,13 +61,13 @@ fdb-operator-76d6dc9df-dcvmg   1/1     Running   0          3m10s
 Command (for copy paste):
 
 ```
-kubectl apply -k tigris-deploy/fdb-cluster/base
+kubectl apply -k tigris-deploy/fdb-cluster/overlays/example
 ```
 
 Output:
 
 ```
-$ kubectl apply -k tigris-deploy/fdb-cluster/base
+$ kubectl apply -k tigris-deploy/fdb-cluster/overlays/example
 Warning: apps.foundationdb.org/v1beta1 FoundationDBCluster is deprecated; use apps.foundationdb.org/v1beta2 FoundationDBCluster
 foundationdbcluster.apps.foundationdb.org/fdb-cluster created
 ```
@@ -75,21 +75,10 @@ foundationdbcluster.apps.foundationdb.org/fdb-cluster created
 Expected state:
 
 ```
-$ kubectl get pods
-NAME                           READY   STATUS    RESTARTS   AGE
-fdb-operator-76d6dc9df-dq462   1/1     Running   0          3m10s
-fdb-cluster-log-1              2/2     Running   0          63s
-fdb-cluster-log-2              2/2     Running   0          63s
-fdb-cluster-log-3              2/2     Running   0          63s
-fdb-cluster-stateless-1        2/2     Running   0          63s
-fdb-cluster-stateless-2        2/2     Running   0          63s
-fdb-cluster-stateless-3        2/2     Running   0          63s
-fdb-cluster-stateless-4        2/2     Running   0          63s
-fdb-cluster-stateless-5        2/2     Running   0          63s
-fdb-cluster-stateless-6        2/2     Running   0          63s
-fdb-cluster-stateless-7        2/2     Running   0          63s
-fdb-cluster-stateless-8        2/2     Running   0          63s
-fdb-cluster-storage-1          2/2     Running   0          63s
+$ kubectl get pods | grep fdb-cluster
+fdb-cluster-log-1              2/2     Running   0             38s
+fdb-cluster-stateless-1        2/2     Running   0             38s
+fdb-cluster-storage-1          2/2     Running   0             38s
 ```
 
 # Deploy Tigris Search
@@ -97,13 +86,13 @@ fdb-cluster-storage-1          2/2     Running   0          63s
 Command (for copy paste):
 
 ```
-kubectl apply -k tigris-deploy/tigris-search/base
+kubectl apply -k tigris-deploy/tigris-search/overlays/example
 ```
 
 Output:
 
 ```
-$ kubectl apply -k tigris-deploy/tigris-search/base
+$ kubectl apply -k tigris-deploy/tigris-search/overlays/example
 serviceaccount/typesense-service-account created
 role.rbac.authorization.k8s.io/typesense-role created
 rolebinding.rbac.authorization.k8s.io/typesense-role-binding created
@@ -126,13 +115,13 @@ tigris-search-0                2/2     Running   1 (2m11s ago)   2m30s
 Command (for copy paste):
 
 ```
-kubectl apply -k tigris-deploy/tigris-server/base
+kubectl apply -k tigris-deploy/tigris-server/overlays/example
 ```
 
 Output:
 
 ```
-$ kubectl apply -k tigris-deploy/tigris-server/base
+$ kubectl apply -k tigris-deploy/tigris-server/overlays/example
 configmap/tigris-server-config-b8m5mtk96k created
 service/tigris-grpc created
 service/tigris-headless created
@@ -151,62 +140,31 @@ tigris-server-5c66756cc7-lk5gp   1/1     Running   0               80s
 # Final overview
 
 ```
-$ kubectl get all,pvc,pv,configmap
-NAME                                 READY   STATUS    RESTARTS      AGE
-pod/fdb-operator-76d6dc9df-dq462     1/1     Running   0             21m
-pod/fdb-cluster-log-1                2/2     Running   0             19m
-pod/fdb-cluster-log-2                2/2     Running   0             19m
-pod/fdb-cluster-log-3                2/2     Running   0             19m
-pod/fdb-cluster-stateless-1          2/2     Running   0             19m
-pod/fdb-cluster-stateless-2          2/2     Running   0             19m
-pod/fdb-cluster-stateless-3          2/2     Running   0             19m
-pod/fdb-cluster-stateless-4          2/2     Running   0             19m
-pod/fdb-cluster-stateless-5          2/2     Running   0             19m
-pod/fdb-cluster-stateless-6          2/2     Running   0             19m
-pod/fdb-cluster-stateless-7          2/2     Running   0             19m
-pod/fdb-cluster-stateless-8          2/2     Running   0             19m
-pod/fdb-cluster-storage-1            2/2     Running   0             19m
-pod/tigris-search-0                  2/2     Running   1 (10m ago)   10m
-pod/tigris-server-5c66756cc7-lk5gp   1/1     Running   0             2m7s
+$ kubectl get all
+NAME                                 READY   STATUS    RESTARTS       AGE
+pod/fdb-operator-76d6dc9df-dq462     1/1     Running   1 (27m ago)    6h40m
+pod/fdb-cluster-log-1                2/2     Running   0              12m
+pod/fdb-cluster-stateless-1          2/2     Running   0              12m
+pod/fdb-cluster-storage-1            2/2     Running   0              12m
+pod/tigris-search-0                  2/2     Running   1 (108s ago)   111s
+pod/tigris-server-5c66756cc7-w8ccm   1/1     Running   0              57s
 
 NAME                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
-service/kubernetes        ClusterIP   10.43.0.1       <none>        443/TCP        17h
-service/tigris-search     NodePort    10.43.9.203     <none>        80:32051/TCP   10m
-service/ts                ClusterIP   None            <none>        8108/TCP       10m
-service/tigris-grpc       NodePort    10.43.33.91     <none>        80:30782/TCP   2m7s
-service/tigris-headless   ClusterIP   None            <none>        8080/TCP       2m7s
-service/tigris-http       NodePort    10.43.217.209   <none>        80:32186/TCP   2m7s
+service/kubernetes        ClusterIP   10.43.0.1       <none>        443/TCP        23h
+service/tigris-search     NodePort    10.43.89.125    <none>        80:30029/TCP   111s
+service/ts                ClusterIP   None            <none>        8108/TCP       111s
+service/tigris-grpc       NodePort    10.43.167.86    <none>        80:31021/TCP   57s
+service/tigris-headless   ClusterIP   None            <none>        8080/TCP       57s
+service/tigris-http       NodePort    10.43.137.191   <none>        80:31775/TCP   57s
 
 NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
-deployment.apps/fdb-operator    1/1     1            1           13h
-deployment.apps/tigris-server   1/1     1            1           2m7s
+deployment.apps/fdb-operator    1/1     1            1           19h
+deployment.apps/tigris-server   1/1     1            1           57s
 
 NAME                                       DESIRED   CURRENT   READY   AGE
-replicaset.apps/fdb-operator-76d6dc9df     1         1         1       13h
-replicaset.apps/tigris-server-5c66756cc7   1         1         1       2m7s
+replicaset.apps/fdb-operator-76d6dc9df     1         1         1       19h
+replicaset.apps/tigris-server-5c66756cc7   1         1         1       57s
 
 NAME                             READY   AGE
-statefulset.apps/tigris-search   1/1     10m
-
-NAME                                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-persistentvolumeclaim/fdb-cluster-log-2-data       Bound    pvc-46d8518c-d3a4-4f6c-9094-16e455c919dc   128G       RWO            local-path     19m
-persistentvolumeclaim/fdb-cluster-storage-1-data   Bound    pvc-2148725f-2631-4a30-8221-f2ee7548ad79   128G       RWO            local-path     19m
-persistentvolumeclaim/fdb-cluster-log-1-data       Bound    pvc-d22a49a1-bf98-4452-b334-9e177377a848   128G       RWO            local-path     19m
-persistentvolumeclaim/fdb-cluster-log-3-data       Bound    pvc-bcc0125b-fcf1-48a6-b39e-4be4cc01256c   128G       RWO            local-path     19m
-persistentvolumeclaim/data-tigris-search-0         Bound    pvc-608923ad-289d-4b9a-a291-4f2179e2f7a7   100Mi      RWO            local-path     10m
-
-NAME                                                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                STORAGECLASS   REASON   AGE
-persistentvolume/pvc-46d8518c-d3a4-4f6c-9094-16e455c919dc   128G       RWO            Delete           Bound    default/fdb-cluster-log-2-data       local-path              19m
-persistentvolume/pvc-2148725f-2631-4a30-8221-f2ee7548ad79   128G       RWO            Delete           Bound    default/fdb-cluster-storage-1-data   local-path              19m
-persistentvolume/pvc-d22a49a1-bf98-4452-b334-9e177377a848   128G       RWO            Delete           Bound    default/fdb-cluster-log-1-data       local-path              19m
-persistentvolume/pvc-bcc0125b-fcf1-48a6-b39e-4be4cc01256c   128G       RWO            Delete           Bound    default/fdb-cluster-log-3-data       local-path              18m
-persistentvolume/pvc-608923ad-289d-4b9a-a291-4f2179e2f7a7   100Mi      RWO            Delete           Bound    default/data-tigris-search-0         local-path              10m
-
-NAME                                        DATA   AGE
-configmap/kube-root-ca.crt                  1      17h
-configmap/fdb-cluster-config                5      19m
-configmap/check-ready-6274gh564t            1      10m
-configmap/setup-thkgc9t57d                  1      10m
-configmap/tigris-server-config-b8m5mtk96k   1      2m7s
-configmap/fdb-kubernetes-operator           0      13h
+statefulset.apps/tigris-search   1/1     111s
 ```

--- a/fdb-cluster/overlays/example/kustomization.yaml
+++ b/fdb-cluster/overlays/example/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - processes.yaml

--- a/fdb-cluster/overlays/example/processes.yaml
+++ b/fdb-cluster/overlays/example/processes.yaml
@@ -1,0 +1,28 @@
+# This is a sample configuration for running a FoundationDB cluster.
+apiVersion: apps.foundationdb.org/v1beta1
+kind: FoundationDBCluster
+metadata:
+  name: fdb-cluster
+spec:
+  version: 7.1.7
+  processCounts:
+    log: 1
+    stateless: 1
+  processes:
+    general:
+      podTemplate:
+        spec:
+          containers:
+            - name: foundationdb
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+            - name: foundationdb-kubernetes-sidecar
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi

--- a/fdb-operator/values.yaml
+++ b/fdb-operator/values.yaml
@@ -50,7 +50,7 @@ containerSecurityContext:
   privileged: false
   capabilities:
     drop:
-    - all
+      - all
   readOnlyRootFilesystem: true
 
 nodeSelector: {}
@@ -80,5 +80,5 @@ initContainerSecurityContext:
   privileged: false
   capabilities:
     drop:
-    - all
+      - all
   readOnlyRootFilesystem: true

--- a/tigris-search/base/check_ready.sh
+++ b/tigris-search/base/check_ready.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
+# Copyright 2022 Tigris Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 TSHOST=localhost
 TSPORT=8108

--- a/tigris-search/base/kustomization.yaml
+++ b/tigris-search/base/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 Tigris Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/tigris-search/base/rbac.yaml
+++ b/tigris-search/base/rbac.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 Tigris Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/tigris-search/base/service-headless.yaml
+++ b/tigris-search/base/service-headless.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 Tigris Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # headless service used by cluster members to resolve ip's
 apiVersion: v1
 kind: Service

--- a/tigris-search/base/sts.yaml
+++ b/tigris-search/base/sts.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 Tigris Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -49,10 +63,10 @@ spec:
             timeoutSeconds: 5
           resources:
             limits:
-              cpu: "2"
-              memory: "1Gi"
+              cpu: "100m"
+              memory: "512Mi"
             requests:
-              cpu: "1"
+              cpu: "100m"
               memory: "512Mi"
           env:
             - name: TYPESENSE_DATA_DIR

--- a/tigris-search/overlays/example/kustomization.yaml
+++ b/tigris-search/overlays/example/kustomization.yaml
@@ -12,4 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-tigris-search-0.ts:8107:8108
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/tigris-server/overlays/example/kustomization.yaml
+++ b/tigris-server/overlays/example/kustomization.yaml
@@ -12,4 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-tigris-search-0.ts:8107:8108
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base


### PR DESCRIPTION
Tapers down FDB and TypeSense resource requirements a bit to make it feasible to run Tigris on laptops.

Tested with 2 vCPUs and 8G RAM.