### PR TITLE
Upgrade FDB API to v1beta2

### DIFF
--- a/helm/fdb-cluster/templates/foundationdbcluster.yaml
+++ b/helm/fdb-cluster/templates/foundationdbcluster.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-apiVersion: apps.foundationdb.org/v1beta1
+apiVersion: apps.foundationdb.org/v1beta2
 kind: FoundationDBCluster
 metadata:
   name: fdb-cluster

--- a/kustomize/fdb-cluster/base/foundationdbcluster.yaml
+++ b/kustomize/fdb-cluster/base/foundationdbcluster.yaml
@@ -1,5 +1,5 @@
 # This is a sample configuration for running a FoundationDB cluster.
-apiVersion: apps.foundationdb.org/v1beta1
+apiVersion: apps.foundationdb.org/v1beta2
 kind: FoundationDBCluster
 metadata:
   name: fdb-cluster

--- a/kustomize/fdb-cluster/overlays/example/processes.yaml
+++ b/kustomize/fdb-cluster/overlays/example/processes.yaml
@@ -1,5 +1,5 @@
 # This is a sample configuration for running a FoundationDB cluster.
-apiVersion: apps.foundationdb.org/v1beta1
+apiVersion: apps.foundationdb.org/v1beta2
 kind: FoundationDBCluster
 metadata:
   name: fdb-cluster


### PR DESCRIPTION
```
$ helm install fdb-operator fdb-operator
NAME: fdb-operator
LAST DEPLOYED: Fri Oct  7 22:27:40 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
FoundationDB operator has been installed successfully.

To see the logs of the operator you can use below command
kubectl logs deployment/fdb-operator -n default -f

Thanks for trying out FoundationDB helm chart.
```

```
ubuntu@ip-172-31-5-145:~/tigris-deploy/helm$ helm install fdb-cluster fdb-cluster -f fdb-cluster/values-local.yaml
NAME: fdb-cluster
LAST DEPLOYED: Fri Oct  7 22:28:09 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```