### PR TITLE
Synchronize base manifests

### DIFF
--- a/kustomize/fdb-cluster/base/foundationdbcluster.yaml
+++ b/kustomize/fdb-cluster/base/foundationdbcluster.yaml
@@ -13,5 +13,5 @@ spec:
     # Default process counts
     # logs = 3, proxies = 3, resolvers = 1, master = 1, cluster_controller = 1, rate_keeper = 1, data_distributor = 1
     # stateless = proxies + resolvers + master + cluster_controller + rate_keeper + data_distributor
-    redundancy_mode: single
+    redundancy_mode: triple
     usable_regions: 1

--- a/kustomize/fdb-cluster/overlays/example/processes.yaml
+++ b/kustomize/fdb-cluster/overlays/example/processes.yaml
@@ -4,6 +4,8 @@ kind: FoundationDBCluster
 metadata:
   name: fdb-cluster
 spec:
+  databaseConfiguration:
+    redundancy_mode: single
   version: 7.1.7
   processCounts:
     log: 1


### PR DESCRIPTION
Make default redundancy for FoundationDB be triple, reduce redundancy only for local/example install.