### PR TITLE
Support EKS deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,12 @@ persistentvolumeclaim/fdb-cluster-storage-1-data   Bound    pvc-a71b1576-fe83-4b
 NAME                                      CLASS   HOSTS   ADDRESS   PORTS   AGE
 ingress.networking.k8s.io/tigris-server   nginx   *                 80      3m42s
 ```
+
+# EKS Deployment
+
+EKS based deployments use AWS load balancers with annotations. ALBs can be enabled with:
+
+```
+ingress-aws:
+  enabled: true
+```

--- a/helm/tigris-server/templates/ingress.yaml
+++ b/helm/tigris-server/templates/ingress.yaml
@@ -21,9 +21,33 @@ metadata:
     app.kubernetes.io/part-of: tigris
     app.kubernetes.io/component: server
   annotations:
+    {{- if .Values.ingress_nginx.enabled }}
     nginx.ingress.kubernetes.io/rewrite-target: /
+    {{- end }}
+    {{- if .Values.ingress_aws.enabled }}
+    alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.lb_name }}
+    alb.ingress.kubernetes.io/group.name: {{ .Values.lb_name }}
+    {{- if .Values.tls_hostname }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.tls_hostname }}
+    {{- end }}
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/conditions.tigris-grpc: |
+      [{"field":"http-header","httpHeaderConfig":{"httpHeaderName": "Content-Type", "values":["application/grpc"]}}]
+    alb.ingress.kubernetes.io/healthcheck-path: /v1/health
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/load-balancer-attributes: routing.http.drop_invalid_header_fields.enabled=true
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01 # disable support for TLS 1.0, 1.1 and weak ciphers
+    alb.ingress.kubernetes.io/tags: service=tigris-server
+    alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.app_cookie.duration_seconds=10,stickiness.type=app_cookie,stickiness.app_cookie.cookie_name=Tigris-Tx-Id
+    alb.ingress.kubernetes.io/target-type: ip
+    external-dns.alpha.kubernetes.io/ingress-hostname-source: annotation-only
+    {{- end }}
 spec:
+  {{- if .Values.ingress_nginx.enabled }}
   ingressClassName: nginx
+  {{- end }}
   rules:
     - http:
         paths:
@@ -76,3 +100,8 @@ spec:
                 name: tigris-grpc
                 port:
                   number: {{ .Values.service_port | default 80 }}
+  {{- if and .Values.ingress_aws.enabled (ne .Values.tls_hostname "") }}
+  tls:
+    - hosts:
+        - {{ .Values.tls_hostname }}
+  {{- end }}

--- a/helm/tigris-server/values.yaml
+++ b/helm/tigris-server/values.yaml
@@ -38,3 +38,15 @@ resources:
   requests:
     cpu: "1"
     memory: "512Mi"
+
+# Enable TLS hostname
+tls_hostname: ""
+
+# Load balancer name
+lb_name: tigris-server-lb
+
+ingress_nginx:
+  enabled: false
+
+ingress_aws:
+  enabled: false

--- a/helm/tigris-stack/Chart.yaml
+++ b/helm/tigris-stack/Chart.yaml
@@ -17,6 +17,7 @@ dependencies:
   - name: ingress-nginx
     version: 4.3.0
     repository: https://kubernetes.github.io/ingress-nginx
+    condition: tigris-server.ingress_nginx.enabled
   - name: tigris-server
     version: 0.1.0
     repository: file://../tigris-server

--- a/helm/tigris-stack/values-local.yaml
+++ b/helm/tigris-stack/values-local.yaml
@@ -102,7 +102,12 @@ grafana:
   extraInitContainers:
     - name: waitfor-victoriametrics
       image: busybox:latest
-      command: ['sh', '-c', 'until nc -vz tigris-stack-victoria-metrics-single-server.default 8428 ; do echo "Waiting for victoriametrics..."; sleep 3; done;']
+      command:
+        [
+          "sh",
+          "-c",
+          'until nc -vz tigris-stack-victoria-metrics-single-server.default 8428 ; do echo "Waiting for victoriametrics..."; sleep 3; done;',
+        ]
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -115,3 +120,6 @@ grafana:
           isDefault: true
           updateIntervalSeconds: 10
           editable: true
+
+ingress-nginx:
+  enabled: true

--- a/helm/tigris-stack/values.yaml
+++ b/helm/tigris-stack/values.yaml
@@ -13,10 +13,6 @@
 # limitations under the License.
 #
 
-enable-components:
-  vmsingle: false
-  vmcluster: false
-
 ### FoundationDB Cluster related settings
 fdb-cluster:
   usable_regions: 1
@@ -92,3 +88,12 @@ tigris-server:
     requests:
       cpu: "1"
       memory: "512Mi"
+
+aws-load-balancer-controller:
+  clusterName: tigris-server
+
+grafana:
+  enabled: false
+
+victoria-metrics-single:
+  enabled: false


### PR DESCRIPTION
Adds manifests to support EKS deployments.

Synopsis:
```
$ helm install tigris-stack . -f ./values.yaml --set tigris-server.ingress_aws.enabled=true --set tigris-server.tls_hostname="api.doc.tigrisdata.cloud" --set tigris-search.replicas=1
```

Tested with blog! =]